### PR TITLE
Create new action takes logdir as input path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -210,6 +210,9 @@ export function addCommands(
     execute: args => {
       const cwd = (args['cwd'] as string) || fileBrowser.model.path;
       const logdir = typeof args['logdir'] === 'undefined' ? cwd : (args['logdir'] as string);
+      fileBrowser.model.cd(logdir).catch(error => {
+        console.error(`Error changing to the new path ${logdir}:`, error);
+      });
       return serviceManager.contents.get(logdir, { type: 'directory' }).then(
         dir => {
           // Try to open the session panel to make it easier for users to observe more active tensorboard instances
@@ -218,11 +221,7 @@ export function addCommands(
           } catch (e) {
             // do nothing
           }
-          fileBrowser.model.cd(logdir).then(()=>{
-            app.commands.execute(CommandIDs.open);
-          }).catch(error => {
-            console.error(`Error changing to the new path ${logdir}:`, error);
-          });
+          app.commands.execute(CommandIDs.open);
         },
         () => {
           // no such directory.

--- a/src/index.ts
+++ b/src/index.ts
@@ -218,7 +218,11 @@ export function addCommands(
           } catch (e) {
             // do nothing
           }
-          app.commands.execute(CommandIDs.open);
+          fileBrowser.model.cd(logdir).then(()=>{
+            app.commands.execute(CommandIDs.open);
+          }).catch(error => {
+            console.error(`Error changing to the new path ${logdir}:`, error);
+          });
         },
         () => {
           // no such directory.


### PR DESCRIPTION
Passing cwd or logdir to create-new actually changes the location on the file browser so that tensorboard actually starts at this path.

currently passing cwd or logdir had no effect