### PR TITLE
Changes for JupyterHub >= 4.1

### DIFF
--- a/jupyterlab_tensorboard_pro/handlers.py
+++ b/jupyterlab_tensorboard_pro/handlers.py
@@ -101,6 +101,14 @@ class TensorboardHandler(JupyterHandler):
         See https://github.com/tensorflow/tensorboard/issues/4685
 
         """
+        if not hasattr(self, "_jupyter_current_user"):
+            # Called too early, will be checked later
+            return None
+
+        if self.token_authenticated or self.settings.get("disable_check_xsrf", False):
+            # Token-authenticated requests do not need additional XSRF-check
+            # Servers without authentication are vulnerable to XSRF
+            return None
 
         # Check XSRF token
         try:


### PR DESCRIPTION
Adapts to some changes for XSRF processing upstream - ensuring we don't call some of the parent methods before authentication info is available.