### PR TITLE
Compatibility with tornado 6.3+ to address  [CVE-2024-52804]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup_args = dict(
     packages=setuptools.find_packages(),
     install_requires=[
         "jupyterlab>=4.0",
-        "tornado<=6.2",
+        "tornado>=6.4.2",
     ],
     zip_safe=False,
     include_package_data=True,


### PR DESCRIPTION
This PR allows us to use latest version of tornado (6.4.2) as of 11/26/2024 to address [[CVE-2024-52804](https://github.com/advisories/GHSA-8w49-h785-mj3c)](https://github.com/advisories/GHSA-8w49-h785-mj3c)

- call Tensorboard WSGI app directly since WSGIContainer from tornado is not compatible with it due to the [ThreadPoolExecutor update](https://github.com/tornadoweb/tornado/pull/3231)
- Relax tornado version requirement